### PR TITLE
Fixed game crashes and few improvements

### DIFF
--- a/changes/1.20.1-1.6.1.md
+++ b/changes/1.20.1-1.6.1.md
@@ -1,0 +1,4 @@
+- Added decay in heat level for flowing fluids
+- Minimum heat source shows next higher level if current is not present
+- Fixed crash when Create mod is not present
+- Fixed crash regarding the flywheel

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=false
 
 use_parchment = true
 
-mod_version=1.6.0
+mod_version=1.6.1
 modid=melter
 author=oierbravo
 display_name=Melter

--- a/src/main/java/com/oierbravo/melter/compat/jei/HeatSourceCategory.java
+++ b/src/main/java/com/oierbravo/melter/compat/jei/HeatSourceCategory.java
@@ -109,7 +109,7 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
         List<Recipe> recipes = new ArrayList<>();
 
         for (HeatSources.Config hs : HeatSources.getHeatSourcesConfig()) {
-            Melter.LOGGER.info("processing: " + hs.name());
+            Melter.LOGGER.info("processing heat source: " + hs.name());
             var rl = hs.rl();
             if (hs.type().equals(HeatSources.Type.BLOCK)) {
                 var item = BuiltInRegistries.ITEM.get(rl);
@@ -135,9 +135,13 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
                         case "minecraft:soul_fire" -> new ItemStack(Items.FIRE_CHARGE).setHoverName(Component.translatable("block.minecraft.soul_fire").withStyle(ChatFormatting.DARK_AQUA, ChatFormatting.BOLD));
                         case "minecraft:wall_torch" -> new ItemStack(Items.TORCH);
                         case "minecraft:soul_wall_torch" -> new ItemStack(Items.SOUL_TORCH);
-                        case "create:lit_blaze_burner" -> new ItemStack(AllBlocks.BLAZE_BURNER);
+                        case "create:lit_blaze_burner" -> Melter.withCreate ? new ItemStack(AllBlocks.BLAZE_BURNER) : new ItemStack(Blocks.AIR);
                         default -> new ItemStack(block);
                     };
+
+                    if (is.is(Blocks.AIR.asItem())) {
+                        continue;
+                    }
 
                     boolean isItemStackPresent = recipes.stream()
                         .filter(r -> r.block != null)
@@ -145,7 +149,7 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
 
                     if (!isItemStackPresent) {
                         recipes.add(new Recipe(is, null, heat, hs.description()));
-                        Melter.LOGGER.info("added block: " + hs.name());
+                        Melter.LOGGER.info("added heat source block: " + hs.name());
                     }
                 }
             }
@@ -166,7 +170,7 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
 
                     if (!isFluidStackPresent) {
                         recipes.add(new Recipe(null, fs, heat, hs.description()));
-                        Melter.LOGGER.info("added fluid: " + hs.name());
+                        Melter.LOGGER.info("added heat source fluid: " + hs.name());
                     }
                 }
             }

--- a/src/main/java/com/oierbravo/melter/content/melter/MelterBlockEntity.java
+++ b/src/main/java/com/oierbravo/melter/content/melter/MelterBlockEntity.java
@@ -34,9 +34,8 @@ import java.util.Optional;
 
 public class MelterBlockEntity extends BlockEntity  {
 
-
     private final int FLUID_CAPACITY = MelterConfig.MELTER_CAPACITY.get();
-    private static final int FLIUD_PER_TICK = MelterConfig.MELTER_FLUID_PER_TICK.get();
+
     private CompoundTag updateTag;
     public final ItemStackHandler inputItems = createInputItemHandler();
     private final LazyOptional<IItemHandler> inputItemHandler = LazyOptional.of(() -> inputItems);
@@ -47,6 +46,7 @@ public class MelterBlockEntity extends BlockEntity  {
     public int progress = 0;
     public int maxProgress = 200;
     private BlockState lastBlockState;
+
     public MelterBlockEntity(BlockEntityType<?> pType, BlockPos pWorldPosition, BlockState pBlockState) {
         super(pType, pWorldPosition, pBlockState);
         updateTag = getPersistentData();

--- a/src/main/java/com/oierbravo/melter/content/melter/MelterBlockRenderer.java
+++ b/src/main/java/com/oierbravo/melter/content/melter/MelterBlockRenderer.java
@@ -1,8 +1,8 @@
 package com.oierbravo.melter.content.melter;
 
-import com.jozufozu.flywheel.util.transform.TransformStack;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -24,6 +24,7 @@ import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
 public class MelterBlockRenderer implements BlockEntityRenderer<MelterBlockEntity> {
+
     public MelterBlockRenderer(BlockEntityRendererProvider.Context context) {
     }
 
@@ -46,9 +47,8 @@ public class MelterBlockRenderer implements BlockEntityRenderer<MelterBlockEntit
                 pPoseStack.translate(0.5d, 0.8d * percent, 0.5d);
             }
             else {
-                TransformStack msr = TransformStack.cast(pPoseStack);
                 pPoseStack.translate(0.5d, 0.8d * percent + 0.175d, 0.6d);
-                msr.rotateX(-90);
+                pPoseStack.rotateAround(Axis.XN.rotationDegrees(90), 0, 0, 0);
             }
             this.renderBlock(pPoseStack,pBufferSource,pPackedLight,pPackedOverlay,itemStack,pBlockEntity);
             pPoseStack.popPose();

--- a/src/main/java/com/oierbravo/melter/content/melter/MelterConfig.java
+++ b/src/main/java/com/oierbravo/melter/content/melter/MelterConfig.java
@@ -7,7 +7,6 @@ import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class MelterConfig {
     public static ForgeConfigSpec.IntValue MELTER_CAPACITY;
-    public static ForgeConfigSpec.IntValue MELTER_FLUID_PER_TICK;
     public static ConfigValue<List<? extends List<? extends String>>> HEAT_SOURCES;
 
     public static void registerServerConfig(ForgeConfigSpec.Builder builder) {
@@ -15,9 +14,6 @@ public class MelterConfig {
         MELTER_CAPACITY = builder
                 .comment("How much liquid fits into the melter, in mB")
                 .defineInRange("capacity", 1000, 1, Integer.MAX_VALUE);
-        MELTER_FLUID_PER_TICK = builder
-                .comment("How much liquid generates per tick, in mB")
-                .defineInRange("liquidPerTick", 2, 1, Integer.MAX_VALUE);
         HEAT_SOURCES = builder
                 .comment("List of heat source blocks or fluids. Each element in a list must follow the order: type (block, fluid), name, heat level (1-10), additional information shown in JEI")
                 .defineList("heatSources", Arrays.asList(


### PR DESCRIPTION
Hello!
Here's the change list:

## Fixed game crash when Create mod is not present
The first game crash occurs while the recipe is loading. which uses a heat level that some Create block has, but the Create mod is not present.

> [Render thread/DEBUG] [me.je.li.re.RecipeManagerInternal/]: Adding recipes: melter:melting
[Render thread/ERROR] [me.je.li.ut.IngredientSupplierHelper/]: Found a broken recipe, failed to setRecipe with RecipeLayoutBuilder: Melter melter:melting/ice class com.oierbravo.melter.content.melter.MeltingRecipe
java.lang.NoClassDefFoundError: com/simibubi/create/AllBlocks
	at com.oierbravo.melter.content.melter.HeatSources.lambda$getHeatSourcesForHeatLevel$8(HeatSources.java:131) ~[melter-679027-5533137_mapped_parchment_2023.09.03-1.20.1.jar:1.20.1-1.6.0] {re:classloading}
	at com.oierbravo.melter.content.melter.HeatSources.getHeatSourcesForHeatLevel(HeatSources.java:123) ~[melter-679027-5533137_mapped_parchment_2023.09.03-1.20.1.jar:1.20.1-1.6.0] {re:classloading}

## Fixed game crash regarding the flywheel
The second game crash occurs when trying to use the Melter block. It has to do with the way I rotated items. I've replaced the Flywheel code with the vanilla one.

> java.lang.NoClassDefFoundError: com/jozufozu/flywheel/util/transform/TransformStack
	at com.oierbravo.melter.content.melter.MelterBlockRenderer.render(MelterBlockRenderer.java:49) ~[melter-679027-5533137_mapped_parchment_2023.09.03-1.20.1.jar:1.20.1-1.6.0] {re:classloading}
	at com.oierbravo.melter.content.melter.MelterBlockRenderer.render(MelterBlockRenderer.java:26) ~[melter-679027-5533137_mapped_parchment_2023.09.03-1.20.1.jar:1.20.1-1.6.0] {re:classloading}

## Added decay in heat level for flowing fluids

Flowing fluids are now not full heat sources and have some 'decay' from the source block. Only the fluid source blocks have full heat level.

examples:
lava (heat level 4)
![2024-07-16_14 19 24](https://github.com/user-attachments/assets/9181572a-c1eb-44cc-b1b8-c7ecfc0aa7e6)

mekanism superheated sodium (heat level 7)
![2024-07-16_14 19 03](https://github.com/user-attachments/assets/ff265a6f-32cc-45b8-b6e3-c45376c194e1)

## Minimum heat source shows next higher level if current is not present

For example: I have a recipe that melts obsidian into lava and it requires a minimum heat level of 5. But, I have a configuration such that there is no block or fluid with heat level 5, but there is a higher level.
Previously, it would have shown 'No valid heat source found', but now it will "search" for higher levels until it founds something. I've made this change since any level can melt any lower level recipes.

![2024-07-16_13 27 54](https://github.com/user-attachments/assets/f4110596-c074-4eeb-a759-bde940787805)
![2024-07-16_13 28 00](https://github.com/user-attachments/assets/0286bd95-4e67-4933-9879-21068bc11886)

## Fix 'Melter Heat Source' JEI recipe crash

The recipe was not shown in JEI if there is an exception. Now it will log that wrong heat source, but continue adding other valid heat sources.

## Removed unused config

I've realized that the 'FLUID_PER_TICK' is not really necessary and not used. The 'processingTime' in each recipe defines the time it takes to melt, so 'how much liquid generates per tick' does not make sense to me.
